### PR TITLE
Explicitly name segments private networks

### DIFF
--- a/ovn-routed-networks-multiple-segments/Vagrantfile
+++ b/ovn-routed-networks-multiple-segments/Vagrantfile
@@ -1,12 +1,12 @@
-IPS = {central:      '192.168.50.10',
-       central_seg1: '172.24.4.10',
-       worker1:      '192.168.50.100',
-       worker1_seg1: '172.24.4.100',
-       worker2:      '192.168.50.101',
-       worker2_seg2: '172.24.6.101',
-       worker3:      '192.168.50.102',
-       worker3_seg2: '172.24.6.102',
-       iprouter:     '192.168.50.20',
+IPS = {central:        '192.168.50.10',
+       central_seg1_1: '172.24.4.10',
+       worker1:        '192.168.50.100',
+       worker1_seg1_1: '172.24.4.100',
+       worker2:        '192.168.50.101',
+       worker2_seg2_1: '172.24.6.101',
+       worker3:        '192.168.50.102',
+       worker3_seg2_1: '172.24.6.102',
+       iprouter:       '192.168.50.20',
       }
 
 
@@ -17,10 +17,13 @@ Vagrant.configure(2) do |config|
     config.vm.box = "bento/ubuntu-24.04"
     config.vm.synced_folder './', '/vagrant', type: 'rsync'
 
-    # central as controller node (northd/southd) and as compute connected to segment-1
+    # central as controller node (northd/southd) and as compute connected to segment-1-1
     config.vm.define 'central' do |central|
         central.vm.network 'private_network', ip: IPS[:central]
-        central.vm.network 'private_network', ip: IPS[:central_seg1]
+        central.vm.network 'private_network',
+            ip: IPS[:central_seg1_1],
+            libvirt__network_name: "segment-1-1-net",
+            libvirt__iface_name: "central-s1-1"
         central.vm.hostname = 'central'
         central.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -32,14 +35,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'central.sh'
             shell.env = IPS
-            shell.args = ['segment-1']
+            shell.args = ['segment-1-1']
         end
     end
 
-    # openstack compute connected to segment-1
+    # openstack compute connected to segment-1-1
     config.vm.define 'worker1' do |worker1|
         worker1.vm.network 'private_network', ip: IPS[:worker1]
-        worker1.vm.network 'private_network', ip: IPS[:worker1_seg1]
+        worker1.vm.network 'private_network',
+            ip: IPS[:worker1_seg1_1],
+            libvirt__network_name: "segment-1-1-net",
+            libvirt__iface_name: "worker1-s1-1"
         worker1.vm.hostname = 'worker1'
         worker1.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -51,14 +57,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-1']
+            shell.args = ['segment-1-1']
         end
     end
 
-    # openstack compute connected to segment-2
+    # openstack compute connected to segment-2-1
     config.vm.define 'worker2' do |worker2|
         worker2.vm.network 'private_network', ip: IPS[:worker2]
-        worker2.vm.network 'private_network', ip: IPS[:worker2_seg2]
+        worker2.vm.network 'private_network',
+            ip: IPS[:worker2_seg2_1],
+            libvirt__network_name: "segment-2-1-net",
+            libvirt__iface_name: "worker2-s2-1"
         worker2.vm.hostname = 'worker2'
         worker2.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -70,14 +79,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-2']
+            shell.args = ['segment-2-1']
         end
     end
 
-    # openstack compute connected to segment-2
+    # openstack compute connected to segment-2-1
     config.vm.define 'worker3' do |worker3|
         worker3.vm.network 'private_network', ip: IPS[:worker3]
-        worker3.vm.network 'private_network', ip: IPS[:worker3_seg2]
+        worker3.vm.network 'private_network',
+            ip: IPS[:worker3_seg2_1],
+            libvirt__network_name: "segment-2-1-net",
+            libvirt__iface_name: "worker3-s2-1"
         worker3.vm.hostname = 'worker3'
         worker3.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -89,15 +101,23 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-2']
+            shell.args = ['segment-2-1']
         end
     end
 
-    # router between segment-1 and segment-2
+    # router between segment-1-1 and segment-2-1
     config.vm.define 'iprouter' do |iprouter|
         iprouter.vm.network 'private_network', ip: IPS[:iprouter]
-        iprouter.vm.network 'private_network', type: "dhcp", auto_config: false
-        iprouter.vm.network 'private_network', type: "dhcp", auto_config: false
+        iprouter.vm.network 'private_network',
+            type: "dhcp",
+            auto_config: false,
+            libvirt__network_name: "segment-1-1-net",
+            libvirt__iface_name: "iprouter-s1-1"
+        iprouter.vm.network 'private_network',
+            type: "dhcp",
+            auto_config: false,
+            libvirt__network_name: "segment-2-1-net",
+            libvirt__iface_name: "iprouter-s2-1"
         iprouter.vm.hostname = 'iprouter'
         iprouter.vm.provider 'libvirt' do |lb|
             lb.nested = true

--- a/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
+++ b/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
@@ -17,37 +17,28 @@ openstack network delete private
 openstack security group list -c ID -f value  | xargs openstack security group delete
 
 # Add new vlan mappings
-iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges  segment-1:100:102,segment-2:200:202
+iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges segment-1-1:100:102,segment-2-1:200:202
 sudo systemctl restart devstack@neutron-api.service
 sleep 10
 
 # Based on: https://docs.openstack.org/neutron/pike/admin/config-routed-networks.html
-openstack network create --share --provider-physical-network segment-1 --provider-network-type vlan --provider-segment 100 public
-openstack network segment set --name segment-1 $(openstack network segment list --network public -c ID -f value)
-openstack network segment create --physical-network segment-2 --network-type vlan --segment 200 --network public segment-2
-openstack subnet create --network public --network-segment segment-1 --ip-version 4 --subnet-range 172.24.4.0/24 --allocation-pool start=172.24.4.100,end=172.24.4.200 public-segment-1-v4
-openstack subnet create --network public --network-segment segment-2 --ip-version 4 --subnet-range 172.24.6.0/24 --allocation-pool start=172.24.6.100,end=172.24.6.200 public-segment-2-v4
+openstack network create --share --provider-physical-network segment-1-1 --provider-network-type vlan --provider-segment 100 public
+openstack network segment set --name segment-1-1 $(openstack network segment list --network public -c ID -f value)
+openstack network segment create --physical-network segment-2-1 --network-type vlan --segment 200 --network public segment-2-1
+openstack subnet create --network public --network-segment segment-1-1 --ip-version 4 --subnet-range 172.24.4.0/24 --allocation-pool start=172.24.4.100,end=172.24.4.200 public-segment-1-1-v4
+openstack subnet create --network public --network-segment segment-2-1 --ip-version 4 --subnet-range 172.24.6.0/24 --allocation-pool start=172.24.6.100,end=172.24.6.200 public-segment-2-1-v4
 
 # Create security group that accepts ICMP and TCP
 sg_id=$(openstack security group create -c id -f value sg-for-multisegment)
 openstack security group rule create --protocol icmp ${sg_id}
 openstack security group rule create --protocol tcp ${sg_id}
-exit
 
-# create port for VM1 in segment-1
-openstack port create --security-group ${sg_id} --network public --fixed-ip subnet=$(openstack subnet list --name public-segment-1-v4 -c ID -f value),ip-address=172.24.4.110 vm1-segment-1
 
-# create VM2 port in segment-2
-openstack port create --security-group ${sg_id} --network public --fixed-ip subnet=$(openstack subnet list --name public-segment-2-v4 -c ID -f value),ip-address=172.24.6.110 vm2-segment-2
+openstack server create --flavor m1.tiny --network public --availability-zone nova:central --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-central
+openstack server create --flavor m1.tiny --network public --availability-zone nova:worker1 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker1
+openstack server create --flavor m1.tiny --network public --availability-zone nova:worker2 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker2
+openstack server create --flavor m1.tiny --network public --availability-zone nova:worker3 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker3
+sleep 60
+openstack server list --long --column ID --column Name --column Status --column Networks --column Host
 
-# create VM3 port in segment-1
-openstack port create --security-group ${sg_id} --network public --fixed-ip subnet=$(openstack subnet list --name public-segment-1-v4 -c ID -f value),ip-address=172.24.4.120 vm3-segment-1
-
-# create VM1 on worker1
-openstack server create --flavor m1.tiny --nic port-id=$(openstack port list | grep vm1-segment-1 | awk {'print $2'}) --availability-zone nova:worker1 --image cirros-0.4.0-x86_64-disk vm1
-
-# create VM2 on worker2
-openstack server create --flavor m1.tiny --nic port-id=$(openstack port list | grep vm2-segment-2 | awk {'print $2'}) --availability-zone nova:worker2 --image cirros-0.4.0-x86_64-disk vm2
-
-# create VM3 on worker3 (same segment as worker-1)
-openstack server create --flavor m1.tiny --nic port-id=$(openstack port list | grep vm3-segment-1 | awk {'print $2'}) --availability-zone nova:worker3 --image cirros-0.4.0-x86_64-disk vm3
+# To sniff packets sudo tcpdump -i eth2 -e -n -v


### PR DESCRIPTION
The Vagrant private networks used to represent segments are explicitely name to have better control of where the VMs that constitute this environment are connected. The interfaces to those networks are also named to facilitate debugging.

The routed network segments naming convention is updated to better support development of the multiple segments per host functionality.