### PR TITLE
Clone OpenStack projects from Github

### DIFF
--- a/ovn-routed-networks-multiple-segments/central.sh
+++ b/ovn-routed-networks-multiple-segments/central.sh
@@ -7,7 +7,7 @@ segment=$1
 DEBIAN_FRONTEND=noninteractive sudo apt-get update -qqy 
 DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -qqy 
 
-git clone https://opendev.org/openstack/devstack.git ~/devstack
+git clone https://github.com/openstack/devstack.git ~/devstack
 cp /vagrant/local.conf.central /home/vagrant/devstack/local.conf
 cd /home/vagrant/devstack
 sed -i '/ADMIN_PASSWORD/a\STACK_USER=vagrant' /home/vagrant/devstack/local.conf
@@ -15,6 +15,16 @@ sed -i 's/ERROR_ON_CLONE=.*/ERROR_ON_CLONE="False"/' /home/vagrant/devstack/loca
 sed -i 's/HOST_IP=.*/HOST_IP="'${central}'"/' /home/vagrant/devstack/local.conf
 sed -i 's/SERVICE_HOST=.*/SERVICE_HOST="'${central}'"/' /home/vagrant/devstack/local.conf
 sudo chown vagrant:vagrant /opt
+sudo mkdir -p /opt/stack
+sudo chown vagrant:vagrant /opt/stack
+git clone https://github.com/openstack/neutron /opt/stack/neutron
+git clone https://github.com/openstack/nova /opt/stack/nova
+git clone https://github.com/openstack/glance /opt/stack/glance
+git clone https://github.com/openstack/keystone /opt/stack/keystone
+git clone https://github.com/openstack/neutron-tempest-plugin /opt/stack/neutron-tempest-plugin
+git clone https://github.com/openstack/placement /opt/stack/placement
+git clone https://github.com/openstack/requirements /opt/stack/requirements
+git clone https://github.com/openstack/tempest /opt/stack/tempest
 ./stack.sh
 sudo cp /vagrant/rsyncd.conf /etc/.
 sudo systemctl start rsync

--- a/ovn-routed-networks-multiple-segments/worker.sh
+++ b/ovn-routed-networks-multiple-segments/worker.sh
@@ -7,7 +7,7 @@ segment=$1
 DEBIAN_FRONTEND=noninteractive sudo apt-get update -qqy 
 DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -qqy 
 
-git clone https://opendev.org/openstack/devstack.git ~/devstack
+git clone https://github.com/openstack/devstack.git ~/devstack
 cp /vagrant/local.conf.worker /home/vagrant/devstack/local.conf
 cd /home/vagrant/devstack
 sed -i '/ADMIN_PASSWORD/a\STACK_USER=vagrant' /home/vagrant/devstack/local.conf
@@ -19,6 +19,12 @@ sed -i 's/Q_HOST=.*/Q_HOST="'${central}'"/' /home/vagrant/devstack/local.conf
 sed -i 's/RABBIT_HOST=.*/RABBIT_HOST="'${central}'"/' /home/vagrant/devstack/local.conf
 sed -i 's/SERVICE_HOST=.*/SERVICE_HOST="'${central}'"/' /home/vagrant/devstack/local.conf
 sudo chown vagrant:vagrant /opt
+sudo mkdir -p /opt/stack
+sudo chown vagrant:vagrant /opt/stack
+git clone https://github.com/openstack/neutron /opt/stack/neutron
+git clone https://github.com/openstack/nova /opt/stack/nova
+git clone https://github.com/openstack/neutron-tempest-plugin /opt/stack/neutron-tempest-plugin
+git clone https://github.com/openstack/requirements /opt/stack/requirements
 mkdir -p /opt/stack/data/CA
 rsync -avz rsync://${central}/key/ca-bundle.pem /opt/stack/data
 rsync -avz rsync://${central}/CA_data /opt/stack/data/CA


### PR DESCRIPTION
To minimize the time it takes to create a routed networks with multiple segments per host environment, the code for all the OpenStack projects is cloned from github.