### PR TITLE
Rename networks, interfaces and segments

### DIFF
--- a/ovn-routed-networks-multiple-segments/Vagrantfile
+++ b/ovn-routed-networks-multiple-segments/Vagrantfile
@@ -1,11 +1,11 @@
 IPS = {central:        '192.168.50.10',
-       central_seg1_1: '172.24.4.10',
+       central_net_1:  '172.24.4.10',
        worker1:        '192.168.50.100',
-       worker1_seg1_1: '172.24.4.100',
+       worker1_net_1:  '172.24.4.100',
        worker2:        '192.168.50.101',
-       worker2_seg2_1: '172.24.6.101',
+       worker2_net_2:  '172.24.6.101',
        worker3:        '192.168.50.102',
-       worker3_seg2_1: '172.24.6.102',
+       worker3_net_2:  '172.24.6.102',
        iprouter:       '192.168.50.20',
       }
 
@@ -17,13 +17,13 @@ Vagrant.configure(2) do |config|
     config.vm.box = "bento/ubuntu-24.04"
     config.vm.synced_folder './', '/vagrant', type: 'rsync'
 
-    # central as controller node (northd/southd) and as compute connected to segment-1-1
+    # central as controller node (northd/southd) and as compute connected to segment-1-net-1
     config.vm.define 'central' do |central|
         central.vm.network 'private_network', ip: IPS[:central]
         central.vm.network 'private_network',
-            ip: IPS[:central_seg1_1],
-            libvirt__network_name: "segment-1-1-net",
-            libvirt__iface_name: "central-s1-1"
+            ip: IPS[:central_net_1],
+            libvirt__network_name: "segments-net-1",
+            libvirt__iface_name: "central-net-1"
         central.vm.hostname = 'central'
         central.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -35,17 +35,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'central.sh'
             shell.env = IPS
-            shell.args = ['segment-1-1']
+            shell.args = ['segment-1-net-1']
         end
     end
 
-    # openstack compute connected to segment-1-1
+    # openstack compute connected to segment-1-net-1
     config.vm.define 'worker1' do |worker1|
         worker1.vm.network 'private_network', ip: IPS[:worker1]
         worker1.vm.network 'private_network',
-            ip: IPS[:worker1_seg1_1],
-            libvirt__network_name: "segment-1-1-net",
-            libvirt__iface_name: "worker1-s1-1"
+            ip: IPS[:worker1_net_1],
+            libvirt__network_name: "segments-net-1",
+            libvirt__iface_name: "worker1-net-1"
         worker1.vm.hostname = 'worker1'
         worker1.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -57,17 +57,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-1-1']
+            shell.args = ['segment-1-net-1']
         end
     end
 
-    # openstack compute connected to segment-2-1
+    # openstack compute connected to segment-1-net-2
     config.vm.define 'worker2' do |worker2|
         worker2.vm.network 'private_network', ip: IPS[:worker2]
         worker2.vm.network 'private_network',
-            ip: IPS[:worker2_seg2_1],
-            libvirt__network_name: "segment-2-1-net",
-            libvirt__iface_name: "worker2-s2-1"
+            ip: IPS[:worker2_net_2],
+            libvirt__network_name: "segments-net-2",
+            libvirt__iface_name: "worker2-net-2"
         worker2.vm.hostname = 'worker2'
         worker2.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -79,17 +79,17 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-2-1']
+            shell.args = ['segment-1-net-2']
         end
     end
 
-    # openstack compute connected to segment-2-1
+    # openstack compute connected to segment-1-net-2
     config.vm.define 'worker3' do |worker3|
         worker3.vm.network 'private_network', ip: IPS[:worker3]
         worker3.vm.network 'private_network',
-            ip: IPS[:worker3_seg2_1],
-            libvirt__network_name: "segment-2-1-net",
-            libvirt__iface_name: "worker3-s2-1"
+            ip: IPS[:worker3_net_2],
+            libvirt__network_name: "segments-net-2",
+            libvirt__iface_name: "worker3-net-2"
         worker3.vm.hostname = 'worker3'
         worker3.vm.provider 'libvirt' do |lb|
             lb.nested = true
@@ -101,23 +101,23 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-2-1']
+            shell.args = ['segment-1-net-2']
         end
     end
 
-    # router between segment-1-1 and segment-2-1
+    # router between segment-1-net-1 and segment-1-net-2
     config.vm.define 'iprouter' do |iprouter|
         iprouter.vm.network 'private_network', ip: IPS[:iprouter]
         iprouter.vm.network 'private_network',
             type: "dhcp",
             auto_config: false,
-            libvirt__network_name: "segment-1-1-net",
-            libvirt__iface_name: "iprouter-s1-1"
+            libvirt__network_name: "segments-net-1",
+            libvirt__iface_name: "iprouter-net-1"
         iprouter.vm.network 'private_network',
             type: "dhcp",
             auto_config: false,
-            libvirt__network_name: "segment-2-1-net",
-            libvirt__iface_name: "iprouter-s2-1"
+            libvirt__network_name: "segments-net-2",
+            libvirt__iface_name: "iprouter-net-2"
         iprouter.vm.hostname = 'iprouter'
         iprouter.vm.provider 'libvirt' do |lb|
             lb.nested = true

--- a/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
+++ b/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
@@ -17,16 +17,16 @@ openstack network delete private
 openstack security group list -c ID -f value  | xargs openstack security group delete
 
 # Add new vlan mappings
-iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges segment-1-1:100:102,segment-2-1:200:202
+iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges segment-1-net-1:100:102,segment-1-net-2:200:202
 sudo systemctl restart devstack@neutron-api.service
 sleep 10
 
 # Based on: https://docs.openstack.org/neutron/pike/admin/config-routed-networks.html
-openstack network create --share --provider-physical-network segment-1-1 --provider-network-type vlan --provider-segment 100 public
-openstack network segment set --name segment-1-1 $(openstack network segment list --network public -c ID -f value)
-openstack network segment create --physical-network segment-2-1 --network-type vlan --segment 200 --network public segment-2-1
-openstack subnet create --network public --network-segment segment-1-1 --ip-version 4 --subnet-range 172.24.4.0/24 --allocation-pool start=172.24.4.100,end=172.24.4.200 public-segment-1-1-v4
-openstack subnet create --network public --network-segment segment-2-1 --ip-version 4 --subnet-range 172.24.6.0/24 --allocation-pool start=172.24.6.100,end=172.24.6.200 public-segment-2-1-v4
+openstack network create --share --provider-physical-network segment-1-net-1 --provider-network-type vlan --provider-segment 100 public
+openstack network segment set --name segment-1-net-1 $(openstack network segment list --network public -c ID -f value)
+openstack network segment create --physical-network segment-1-net-2 --network-type vlan --segment 200 --network public segment-1-net-2
+openstack subnet create --network public --network-segment segment-1-net-1 --ip-version 4 --subnet-range 172.24.4.0/24 --allocation-pool start=172.24.4.100,end=172.24.4.200 public-segment-1-net-1-v4
+openstack subnet create --network public --network-segment segment-1-net-2 --ip-version 4 --subnet-range 172.24.6.0/24 --allocation-pool start=172.24.6.100,end=172.24.6.200 public-segment-1-net-2-v4
 
 # Create security group that accepts ICMP and TCP
 sg_id=$(openstack security group create -c id -f value sg-for-multisegment)


### PR DESCRIPTION
Rename networks, interfaces and segments to reflect the fact that with multiple segments per host in routed networks, all the segments will separate vlans on the same physical interface.