### PR TITLE
Add a second segment to each host

### DIFF
--- a/ovn-routed-networks-multiple-segments/Vagrantfile
+++ b/ovn-routed-networks-multiple-segments/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder './', '/vagrant', type: 'rsync'
 
     # central as controller node (northd/southd) and as compute connected to segment-1-net-1
+    # and segment-2-net-1
     config.vm.define 'central' do |central|
         central.vm.network 'private_network', ip: IPS[:central]
         central.vm.network 'private_network',
@@ -35,11 +36,11 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'central.sh'
             shell.env = IPS
-            shell.args = ['segment-1-net-1', '100']
+            shell.args = ['segment-1-net-1', '100', 'segment-2-net-1', '300']
         end
     end
 
-    # openstack compute connected to segment-1-net-1
+    # openstack compute connected to segment-1-net-1 and segment-2-net-1
     config.vm.define 'worker1' do |worker1|
         worker1.vm.network 'private_network', ip: IPS[:worker1]
         worker1.vm.network 'private_network',
@@ -57,11 +58,11 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-1-net-1', '100']
+            shell.args = ['segment-1-net-1', '100', 'segment-2-net-1', '300']
         end
     end
 
-    # openstack compute connected to segment-1-net-2
+    # openstack compute connected to segment-1-net-2 and segment-2-net-2
     config.vm.define 'worker2' do |worker2|
         worker2.vm.network 'private_network', ip: IPS[:worker2]
         worker2.vm.network 'private_network',
@@ -79,11 +80,11 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-1-net-2', '200']
+            shell.args = ['segment-1-net-2', '200', 'segment-2-net-2', '400']
         end
     end
 
-    # openstack compute connected to segment-1-net-2
+    # openstack compute connected to segment-1-net-2 and segment-2-net-2
     config.vm.define 'worker3' do |worker3|
         worker3.vm.network 'private_network', ip: IPS[:worker3]
         worker3.vm.network 'private_network',
@@ -101,11 +102,11 @@ Vagrant.configure(2) do |config|
             shell.privileged = false
             shell.path = 'worker.sh'
             shell.env = IPS
-            shell.args = ['segment-1-net-2', '200']
+            shell.args = ['segment-1-net-2', '200', 'segment-2-net-2', '400']
         end
     end
 
-    # router between segment-1-net-1 and segment-1-net-2
+    # router between segment-1-net-1, segment-2-net-1, segment-1-net-2 and segment-2-net-2
     config.vm.define 'iprouter' do |iprouter|
         iprouter.vm.network 'private_network', ip: IPS[:iprouter]
         iprouter.vm.network 'private_network',

--- a/ovn-routed-networks-multiple-segments/central.sh
+++ b/ovn-routed-networks-multiple-segments/central.sh
@@ -4,6 +4,8 @@ set -x
 hostname=$(hostname)
 segment_1=$1
 vlan_id_1=$2
+segment_2=$3
+vlan_id_2=$4
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get update -qqy
 DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -qqy
@@ -30,7 +32,7 @@ git clone https://github.com/openstack/tempest /opt/stack/tempest
 sudo cp /vagrant/rsyncd.conf /etc/.
 sudo systemctl start rsync
 sudo systemctl enable rsync
-sudo ovs-vsctl set open . external-ids:ovn-bridge-mappings="${segment_1}:br-ex-${vlan_id_1}"
+sudo ovs-vsctl set open . external-ids:ovn-bridge-mappings="${segment_1}:br-ex-${vlan_id_1},${segment_2}:br-ex-${vlan_id_2}"
 
 # Delete created by devstack flat public network
 set +x
@@ -47,7 +49,7 @@ openstack network delete private
 openstack security group list -c ID -f value  | xargs openstack security group delete
 
 # Add new vlan mappings
-iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges segment-1-net-1:4000:4094,segment-1-net-2:4000:4094
+iniset /etc/neutron/plugins/ml2/ml2_conf.ini  ml2_type_vlan network_vlan_ranges segment-1-net-1:4000:4094,segment-1-net-2:4000:4094,segment-2-net-1:4000:4094,segment-2-net-2:4000:4094
 sudo systemctl restart devstack@neutron-api.service
 sleep 10
 
@@ -59,8 +61,17 @@ sudo ovs-vsctl \
 	-- add-port br-ex-${vlan_id_1} patch-${vlan_id_1}-ex \
 	-- set interface patch-${vlan_id_1}-ex type=patch options:peer=patch-ex-${vlan_id_1}
 sudo ovs-vsctl set Port patch-ex-${vlan_id_1} vlan_mode=access tag=${vlan_id_1}
+
+sudo ovs-vsctl add-br br-ex-${vlan_id_2}
+sudo ovs-vsctl \
+	-- add-port br-ex patch-ex-${vlan_id_2} \
+	-- set interface patch-ex-${vlan_id_2} type=patch options:peer=patch-${vlan_id_2}-ex \
+	-- add-port br-ex-${vlan_id_2} patch-${vlan_id_2}-ex \
+	-- set interface patch-${vlan_id_2}-ex type=patch options:peer=patch-ex-${vlan_id_2}
+sudo ovs-vsctl set Port patch-ex-${vlan_id_2} vlan_mode=access tag=${vlan_id_2}
+
 sudo ovs-vsctl add-port br-ex eth2
-sudo ovs-vsctl set Port eth2 vlan_mode=trunk trunks=100,200
+sudo ovs-vsctl set Port eth2 vlan_mode=trunk trunks=${vlan_id_1},${vlan_id_2}
 
 # Set up develpment tools
 curl -LsSf https://astral.sh/ruff/install.sh | sh

--- a/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
+++ b/ovn-routed-networks-multiple-segments/configure-routed-network-resources.sh
@@ -7,21 +7,38 @@ nova-manage cell_v2 discover_hosts
 
 # Based on: https://docs.openstack.org/neutron/pike/admin/config-routed-networks.html
 openstack network create --share --provider-physical-network segment-1-net-1 --provider-network-type vlan --provider-segment 100 public
+
 openstack network segment set --name segment-1-net-1 $(openstack network segment list --network public -c ID -f value)
+openstack network segment create --physical-network segment-2-net-1 --network-type vlan --segment 300 --network public segment-2-net-1
 openstack network segment create --physical-network segment-1-net-2 --network-type vlan --segment 200 --network public segment-1-net-2
+openstack network segment create --physical-network segment-2-net-2 --network-type vlan --segment 400 --network public segment-2-net-2
+
 openstack subnet create --network public --network-segment segment-1-net-1 --ip-version 4 --subnet-range 172.24.4.0/24 --allocation-pool start=172.24.4.100,end=172.24.4.200 public-segment-1-net-1-v4
+openstack subnet create --network public --network-segment segment-2-net-1 --ip-version 4 --subnet-range 172.24.8.0/24 --allocation-pool start=172.24.8.100,end=172.24.8.200 public-segment-2-net-1-v4
 openstack subnet create --network public --network-segment segment-1-net-2 --ip-version 4 --subnet-range 172.24.6.0/24 --allocation-pool start=172.24.6.100,end=172.24.6.200 public-segment-1-net-2-v4
+openstack subnet create --network public --network-segment segment-2-net-2 --ip-version 4 --subnet-range 172.24.12.0/24 --allocation-pool start=172.24.12.100,end=172.24.12.200 public-segment-2-net-2-v4
 
 # Create security group that accepts ICMP and TCP
-sg_id=$(openstack security group create -c id -f value sg-for-multisegment)
-openstack security group rule create --protocol icmp ${sg_id}
-openstack security group rule create --protocol tcp ${sg_id}
+openstack security group rule create --protocol icmp sg-for-multisegment
+openstack security group rule create --protocol tcp sg-for-multisegment
 
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-1-net-1-v4 port-central-segment-1-net-1
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-2-net-1-v4 port-central-segment-2-net-1
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-1-net-1-v4 port-worker1-segment-1-net-1
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-2-net-1-v4 port-worker1-segment-2-net-1
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-1-net-2-v4 port-worker2-segment-1-net-2
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-2-net-2-v4 port-worker2-segment-2-net-2
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-1-net-2-v4 port-worker3-segment-1-net-2
+openstack port create --security-group sg-for-multisegment --network public --fixed-ip subnet=public-segment-2-net-2-v4 port-worker3-segment-2-net-2
 
-openstack server create --flavor m1.tiny --network public --availability-zone nova:central --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-central
-openstack server create --flavor m1.tiny --network public --availability-zone nova:worker1 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker1
-openstack server create --flavor m1.tiny --network public --availability-zone nova:worker2 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker2
-openstack server create --flavor m1.tiny --network public --availability-zone nova:worker3 --image cirros-0.6.2-x86_64-disk --security-group sg-for-multisegment vm-worker3
+openstack server create --flavor m1.tiny --port port-central-segment-1-net-1 --availability-zone nova:central --image cirros-0.6.2-x86_64-disk vm-central-segment-1-net-1
+openstack server create --flavor m1.tiny --port port-central-segment-2-net-1 --availability-zone nova:central --image cirros-0.6.2-x86_64-disk vm-central-segment-2-net-1
+openstack server create --flavor m1.tiny --port port-worker1-segment-1-net-1 --availability-zone nova:worker1 --image cirros-0.6.2-x86_64-disk vm-worker1-segment-1-net-1
+openstack server create --flavor m1.tiny --port port-worker1-segment-2-net-1 --availability-zone nova:worker1 --image cirros-0.6.2-x86_64-disk vm-worker1-segment-2-net-1
+openstack server create --flavor m1.tiny --port port-worker2-segment-1-net-2 --availability-zone nova:worker2 --image cirros-0.6.2-x86_64-disk vm-worker2-segment-1-net-2
+openstack server create --flavor m1.tiny --port port-worker2-segment-2-net-2 --availability-zone nova:worker2 --image cirros-0.6.2-x86_64-disk vm-worker2-segment-2-net-2
+openstack server create --flavor m1.tiny --port port-worker3-segment-1-net-2 --availability-zone nova:worker3 --image cirros-0.6.2-x86_64-disk vm-worker3-segment-1-net-2
+openstack server create --flavor m1.tiny --port port-worker3-segment-2-net-2 --availability-zone nova:worker3 --image cirros-0.6.2-x86_64-disk vm-worker3-segment-2-net-2
 sleep 60
 openstack server list --long --column ID --column Name --column Status --column Networks --column Host
 

--- a/ovn-routed-networks-multiple-segments/iprouter.sh
+++ b/ovn-routed-networks-multiple-segments/iprouter.sh
@@ -12,13 +12,32 @@ sudo ip link set dev eth2 up
 sudo ip link add link eth2 name eth2.100 type vlan id 100
 sudo ip addr add 172.24.4.1/24 dev eth2.100
 sudo ip link set dev eth2.100 up
+sudo ip link add link eth2 name eth2.300 type vlan id 300
+sudo ip addr add 172.24.8.1/24 dev eth2.300
+sudo ip link set dev eth2.300 up
 
 sudo ip link set dev eth3 up
 sudo ip link add link eth3 name eth3.200 type vlan id 200
 sudo ip addr add 172.24.6.1/24 dev eth3.200
 sudo ip link set dev eth3.200 up
+sudo ip link add link eth3 name eth3.400 type vlan id 400
+sudo ip addr add 172.24.12.1/24 dev eth3.400
+sudo ip link set dev eth3.400 up
 
 sudo iptables -A FORWARD -i eth2.100 -o eth3.200 -j ACCEPT
+sudo iptables -A FORWARD -i eth2.100 -o eth3.300 -j ACCEPT
+sudo iptables -A FORWARD -i eth2.100 -o eth3.400 -j ACCEPT
+
 sudo iptables -A FORWARD -i eth3.200 -o eth2.100 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.200 -o eth2.300 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.200 -o eth2.400 -j ACCEPT
+
+sudo iptables -A FORWARD -i eth3.300 -o eth2.100 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.300 -o eth2.200 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.300 -o eth2.400 -j ACCEPT
+
+sudo iptables -A FORWARD -i eth3.400 -o eth2.100 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.400 -o eth2.200 -j ACCEPT
+sudo iptables -A FORWARD -i eth3.400 -o eth2.300 -j ACCEPT
 
 sudo sysctl -w net.ipv4.ip_forward=1

--- a/ovn-routed-networks-multiple-segments/worker.sh
+++ b/ovn-routed-networks-multiple-segments/worker.sh
@@ -4,6 +4,8 @@ set -x
 hostname=$(hostname)
 segment_1=$1
 vlan_id_1=$2
+segment_2=$3
+vlan_id_2=$4
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get update -qqy
 DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -qqy
@@ -30,7 +32,7 @@ mkdir -p /opt/stack/data/CA
 rsync -avz rsync://${central}/key/ca-bundle.pem /opt/stack/data
 rsync -avz rsync://${central}/CA_data /opt/stack/data/CA
 ./stack.sh
-sudo ovs-vsctl set open . external-ids:ovn-bridge-mappings="${segment_1}:br-ex-${vlan_id_1}"
+sudo ovs-vsctl set open . external-ids:ovn-bridge-mappings="${segment_1}:br-ex-${vlan_id_1},${segment_2}:br-ex-${vlan_id_2}"
 
 # Set up segment bridges and patch ports
 sudo ovs-vsctl add-br br-ex-${vlan_id_1}
@@ -40,8 +42,17 @@ sudo ovs-vsctl \
 	-- add-port br-ex-${vlan_id_1} patch-${vlan_id_1}-ex \
 	-- set interface patch-${vlan_id_1}-ex type=patch options:peer=patch-ex-${vlan_id_1}
 sudo ovs-vsctl set Port patch-ex-${vlan_id_1} vlan_mode=access tag=${vlan_id_1}
+
+sudo ovs-vsctl add-br br-ex-${vlan_id_2}
+sudo ovs-vsctl \
+	-- add-port br-ex patch-ex-${vlan_id_2} \
+	-- set interface patch-ex-${vlan_id_2} type=patch options:peer=patch-${vlan_id_2}-ex \
+	-- add-port br-ex-${vlan_id_2} patch-${vlan_id_2}-ex \
+	-- set interface patch-${vlan_id_2}-ex type=patch options:peer=patch-ex-${vlan_id_2}
+sudo ovs-vsctl set Port patch-ex-${vlan_id_2} vlan_mode=access tag=${vlan_id_2}
+
 sudo ovs-vsctl add-port br-ex eth2
-sudo ovs-vsctl set Port eth2 vlan_mode=trunk trunks=100,200
+sudo ovs-vsctl set Port eth2 vlan_mode=trunk trunks=${vlan_id_1},${vlan_id_2}
 
 cp /vagrant/.vimrc ~/.
 cp /vagrant/.editorconfig /opt/stack/neutron/.


### PR DESCRIPTION
A second segment is added to each of the four hosts connected to the routed network. The iprouter VM is updated to be able to route traffic among all the segments in the network. Commands to create ports and VMs for testing connectivity were added.